### PR TITLE
Add support for private IP in KNIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ No           |   role name   |  description
 
 ## Launch Ansible
 ### Preparation
-First, update inventory.
+First, update inventory. The ansible hostvar `ansible_host` is used
+for SSH connection to the target VM (should be public IP), and `klaytn_p2p_host` is used for
+P2P connections between machines (may be private IP).
 
 ```
 [ServiceChainCN]
-SCN1 ansible_user=MY_USER ansible_host=1.2.3.4
+SCN1 ansible_user=MY_USER ansible_host=1.2.3.4 klaytn_p2p_host=10.1.2.3
 
 [controller]
 builder ansible_host=localhost ansible_connecion=local ansible_user=YOUR_USER

--- a/roles/klaytn_node/inventory
+++ b/roles/klaytn_node/inventory
@@ -3,8 +3,8 @@
 #########################################
 
 [ServiceChainCN]
-# SCN01         ansible_host=10.11.12.13  ansible_user=MY_USER
-# SCN02       ansible_host=1.2.3.4      ansible_user=MY_USER
+# SCN01 ansible_host=10.11.12.13 klaytn_p2p_host=10.1.0.8 ansible_user=MY_USER
+# SCN02 ansible_host=1.2.3.4     klaytn_p2p_host=10.1.0.9 ansible_user=MY_USER
 
 [ServiceChainPN]
 # SPN01

--- a/roles/klaytn_node/tasks/download_homi_tool.yml
+++ b/roles/klaytn_node/tasks/download_homi_tool.yml
@@ -39,7 +39,7 @@
   replace:
     path: "{{ homi_root }}/files/homi/output/keys/validator{{ cn_idx +1 }}"
     regexp: "(@[0-9]\\.[0-9]\\.[0-9]\\.[0-9]\\:\\d{1,5}\\?)"
-    replace: "@{{ hostvars[item]['ansible_host'] }}?"
+    replace: "@{{ hostvars[item]['klaytn_p2p_host'] }}?"
   loop: "{{ groups['ServiceChainCN'] }}"
   loop_control:
     index_var: cn_idx


### PR DESCRIPTION
This PR addes `klaytn_p2p_host` variable in order to support private IP to be used for KNIs.

If SCNs only allow inbound connections to P2P port (e.g., 32323) for private IPs, we cannot use public IPs (which is used for SSH) in KNI. That would be the case for [klaytn-terraform](https://github.com/klaytn/klaytn-terraform) which allows inbound connections to P2P port only to the created security group.