### PR TITLE
Add new role for bridge configuration

### DIFF
--- a/roles/klaytn_bridge/README.md
+++ b/roles/klaytn_bridge/README.md
@@ -28,6 +28,7 @@ See all default variables in [defaults/main.yml](defaults/main.yml)
 hash indexing
 - `bridge_anchoring`: an option to enable data enchoring
 - `bridge_anchoring_period`: the period (in block count) for data anchoring
+- `parent_chain_id`: the parent chain's chainID
 - `gen_bridge_info`: an option to generate `bridge_info.json`,
 which can be used for
 [value transfer examples](https://github.com/klaytn/servicechain-value-transfer-examples).

--- a/roles/klaytn_bridge/README.md
+++ b/roles/klaytn_bridge/README.md
@@ -1,0 +1,56 @@
+Ansible Role : klaytn_bridge
+=========
+
+This ansible role enables you to automate bridge configuration for Klaytn.
+
+Requirements
+------------
+
+The target node pair for deploying bridge (e.g., one node for
+the parent chain and the other for the child chain). See
+[klaytn-terraform](https://github.com/klaytn/klaytn-terraform)
+if you have not prepared the node pair for deploying bridge.
+Also, the ansible role [klaytn_node](/roles/klaytn_node) allows
+you to install/configure Klaytn.
+
+Role Variables
+--------------
+
+See all default variables in [defaults/main.yml](defaults/main.yml)
+
+- `parent_service_type`: the type of the node for parent chain (e.g., `kend`)
+- `child_service_type`: the type of the node for child chain (e.g., `kscnd`)
+- `parent_bridge_port`: the bridge port number for the parent chain (main bridge)
+- `child_bridge_port`: the bridge port number for the child chain (sub bridge)
+- `parent_rpc_port`: the RPC port number for the parent chain node
+- `child_rpc_port`: the RPC port number for the child chain node
+- `bridge_indexing`: an option to enable child chain transaction
+hash indexing
+- `bridge_anchoring`: an option to enable data enchoring
+- `bridge_anchoring_period`: the period (in block count) for data anchoring
+- `gen_bridge_info`: an option to generate `bridge_info.json`,
+which can be used for
+[value transfer examples](https://github.com/klaytn/servicechain-value-transfer-examples).
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+```
+- name: Bridge_Setup
+  hosts: all
+  become: true
+  roles:
+    - role: klaytn_bridge
+      parent_service_type: "kend"
+      child_service_type: "kscnd"
+```
+
+License
+-------
+
+MIT

--- a/roles/klaytn_bridge/ansible.cfg
+++ b/roles/klaytn_bridge/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+host_key_checking = False

--- a/roles/klaytn_bridge/defaults/main.yml
+++ b/roles/klaytn_bridge/defaults/main.yml
@@ -13,4 +13,6 @@ child_rpc_port: "8551"
 bridge_anchoring: "1"
 bridge_anchoring_period: "1"
 
+parent_chain_id: "1001"
+
 gen_bridge_info: "yes"

--- a/roles/klaytn_bridge/defaults/main.yml
+++ b/roles/klaytn_bridge/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# defaults file for klaytn_bridge
+parent_service_type: "kend"
+child_service_type: "kscnd"
+
+parent_bridge_port: "50505"
+parent_bridge_indexing: "1"
+child_bridge_port: "50506"
+
+parent_rpc_port: "8551"
+child_rpc_port: "8551"
+
+bridge_anchoring: "1"
+bridge_anchoring_period: "1"
+
+gen_bridge_info: "yes"

--- a/roles/klaytn_bridge/handlers/main.yml
+++ b/roles/klaytn_bridge/handlers/main.yml
@@ -1,0 +1,7 @@
+# handlers file
+- name: restart klaytn
+  systemd:
+    name: "{{ klaytn_service_type }}"
+    state: restarted
+    enabled: yes
+  become: yes

--- a/roles/klaytn_bridge/inventory
+++ b/roles/klaytn_bridge/inventory
@@ -1,0 +1,8 @@
+[ParentBridgeNode]
+PARENT0 ansible_host=1.2.3.4 ansible_user=PARENT_USER
+
+[ChildBridgeNode]
+CHILD0 ansible_host=5.6.7.8 ansible_user=CHILD_USER
+
+[controller]
+builder ansible_host=localhost ansible_connection=local ansible_user=MY_USER

--- a/roles/klaytn_bridge/meta/main.yml
+++ b/roles/klaytn_bridge/meta/main.yml
@@ -1,0 +1,10 @@
+galaxy_info:
+  author:
+    - sawyer.lee@krustuniverse.com
+  description: "Klaytn BlockChain Bridge Configuration"
+  company: Krust Universe
+  license: MIT
+  min_ansible_version: 2.4
+  galaxy_tags: [blockchain, klay, klaytn, ansible, krustuniverse]
+
+dependencies: []

--- a/roles/klaytn_bridge/tasks/bridge.yml
+++ b/roles/klaytn_bridge/tasks/bridge.yml
@@ -1,0 +1,85 @@
+---
+- name: "Run KEN to get parent KNI"
+  shell:
+    cmd: "{{ klaytn_service_type | regex_replace ('d') }} attach --datadir {{ klaytn_node_DATA_DIR }} --exec admin.nodeInfo.kni"
+  register: kni_output
+  become: yes
+  when:
+    - remoteNode|bool
+    - isParent|bool
+
+- name: "Get parent KNI"
+  set_fact:
+    kni: "{{ kni_output.stdout }}"
+  when:
+    - remoteNode|bool
+    - isParent|bool
+
+- name: "Generate main bridges json file"
+  copy:
+    #content: "{{ kni }}"
+    content: "[{{ hostvars['PARENT0']['kni'] }}]"
+    dest: "{{ klaytn_node_DATA_DIR }}/main-bridges.json"
+    force: yes
+  when:
+    - remoteNode|bool
+    - not isParent|bool
+
+- debug: msg="{{ hostvars['PARENT0']['kni'] }}"
+  tags:
+    bridge
+
+- name: Modify main bridges json file
+  replace:
+    path: "{{ klaytn_node_DATA_DIR }}/main-bridges.json"
+    regexp: "(@\\[\\:\\:\\]\\:\\d{1,5}\\?)"
+    replace: "@{{ hostvars['PARENT0']['ansible_host'] }}:{{ parent_bridge_port }}?"
+  when:
+    - remoteNode|bool
+    - not isParent|bool
+
+- name: Add bridge config to parent
+  lineinfile:
+    path: "/etc/{{ klaytn_service_type }}/conf/{{ klaytn_service_type }}.conf"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  loop:
+    - { regexp: '^SC_MAIN_BRIDGE', line: 'SC_MAIN_BRIDGE=1' }
+    - { regexp: '^SC_MAIN_BRIDGE_PORT', line: 'SC_MAIN_BRIDGE_PORT={{ parent_bridge_port }}' }
+    - { regexp: '^SC_MAIN_BRIDGE_INDEXING', line: 'SC_MAIN_BRIDGE_INDEXING={{ parent_bridge_indexing }}' }
+  when:
+    - remoteNode|bool
+    - isParent|bool
+
+- name: Add bridge config to child
+  lineinfile:
+    path: "/etc/{{ klaytn_service_type }}/conf/{{ klaytn_service_type }}.conf"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    backrefs: "yes"
+  loop:
+    - { regexp: '^SC_SUB_BRIDGE', line: 'SC_SUB_BRIDGE=1' }
+    - { regexp: '^SC_SUB_BRIDGE_PORT', line: 'SC_SUB_BRIDGE_PORT={{ child_bridge_port }}' }
+    - { regexp: '^SC_ANCHORING', line: 'SC_ANCHORING=1' }
+    - { regexp: '^SC_ANCHORING_PERIOD', line: 'SC_ANCHORING_PERIOD=1' }
+    - { regexp: '^(RPC_API=)(.*)$', line: '\1subbridge,\2' }
+    - { regexp: '^RPC_ENABLE', line: 'RPC_ENABLE=1' }
+  when:
+    - remoteNode|bool
+    - not isParent|bool
+
+- name: "Restart Klaytn serivce"
+  command: /bin/true
+  notify:
+    - restart klaytn
+  when:
+    - ansible_facts['pkg_mgr'] == 'yum'
+    - remoteNode|bool
+
+- name: "Run Klaytn"
+  # Below command is to run Klaytn in background even after the shell opened by ansible is exited.
+  command: "nohup /opt/{{ klaytn_service_type }}/bin/{{ klaytn_service_type }} start </dev/null >/dev/null 2>&1 &"
+  become: yes
+  when:
+    - ansible_facts['pkg_mgr'] != 'yum'
+    - remoteNode|bool

--- a/roles/klaytn_bridge/tasks/bridge.yml
+++ b/roles/klaytn_bridge/tasks/bridge.yml
@@ -64,6 +64,7 @@
     - { regexp: '^SC_ANCHORING_PERIOD', line: 'SC_ANCHORING_PERIOD=1' }
     - { regexp: '^(RPC_API=)(.*)$', line: '\1subbridge,\2' }
     - { regexp: '^RPC_ENABLE', line: 'RPC_ENABLE=1' }
+    - { regexp: '^SC_PARENT_CHAIN_ID', line: 'SC_PARENT_CHAIN_ID={{ parent_chain_id }}' }
   when:
     - remoteNode|bool
     - not isParent|bool

--- a/roles/klaytn_bridge/tasks/gen_bridge_info.yml
+++ b/roles/klaytn_bridge/tasks/gen_bridge_info.yml
@@ -1,0 +1,87 @@
+---
+- name: "Run command to get parent nodekey"
+  shell:
+    cmd: "cat {{ klaytn_node_DATA_DIR }}/klay/nodekey"
+  register: parent_nodekey_output
+  become: yes
+  when:
+    - remoteNode|bool
+    - isParent|bool
+
+- name: "Get parent nodekey"
+  set_fact:
+    parent_nodekey: "{{ parent_nodekey_output.stdout }}"
+  when:
+    - remoteNode|bool
+    - isParent|bool
+
+- name: "Run KSCN to get parent operator"
+  shell:
+    cmd: "{{ klaytn_service_type | regex_replace ('d') }} attach --datadir {{ klaytn_node_DATA_DIR }} --exec subbridge.parentOperator"
+  register: parent_operator_output
+  become: yes
+  when:
+    - remoteNode|bool
+    - not isParent|bool
+
+- name: "Get parent operator"
+  set_fact:
+    parent_operator: "{{ parent_operator_output.stdout }}"
+  when:
+    - remoteNode|bool
+    - not isParent|bool
+
+- name: "Run command to get child nodekey"
+  shell:
+    cmd: "cat {{ klaytn_node_DATA_DIR }}/klay/nodekey"
+  register: child_nodekey_output
+  become: yes
+  when:
+    - remoteNode|bool
+    - not isParent|bool
+
+- name: "Get child nodekey"
+  set_fact:
+    child_nodekey: "{{ child_nodekey_output.stdout }}"
+  when:
+    - remoteNode|bool
+    - not isParent|bool
+
+- name: "Run KSCN to get child operator"
+  shell:
+    cmd: "{{ klaytn_service_type | regex_replace ('d') }} attach --datadir {{ klaytn_node_DATA_DIR }} --exec subbridge.childOperator"
+  register: child_operator_output
+  become: yes
+  when:
+    - remoteNode|bool
+    - not isParent|bool
+
+- name: "Get child operator"
+  set_fact:
+    child_operator: "{{ child_operator_output.stdout }}"
+  when:
+    - remoteNode|bool
+    - not isParent|bool
+
+- name: "Generate bridge_info.json file"
+  template:
+    src: "bridge_info.j2"
+    dest: "{{ ansible_env.PWD }}/bridge_info.json"
+  when:
+    - not remoteNode|bool
+
+- name: "Restart Klaytn serivce"
+  command: /bin/true
+  notify:
+    - restart klaytn
+  when:
+    - ansible_facts['pkg_mgr'] == 'yum'
+    - remoteNode|bool
+
+- name: "Run Klaytn"
+  # Below command is to run Klaytn in background even after the shell opened by ansible is exited.
+  command: "nohup /opt/{{ klaytn_service_type }}/bin/{{ klaytn_service_type }} start </dev/null >/dev/null 2>&1 &"
+  become: yes
+  when:
+    - ansible_facts['pkg_mgr'] != 'yum'
+    - remoteNode|bool

--- a/roles/klaytn_bridge/tasks/main.yml
+++ b/roles/klaytn_bridge/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# tasks file for klaytn_bridge
+- name: "parent chain"
+  set_fact:
+    klaytn_service_type: "{{ parent_service_type }}"
+    isParent: "yes"
+    remoteNode: "yes"
+  when: inventory_hostname.find('PARENT') != -1
+
+- name: "child chain"
+  set_fact:
+    klaytn_service_type: "{{ child_service_type }}"
+    isParent: "no"
+    remoteNode: "yes"
+  when: inventory_hostname.find('CHILD') != -1
+
+- name: "builder"
+  set_fact:
+    isParent: "no"
+    remoteNode: "no"
+  when: inventory_hostname.find('builder') != -1
+
+- name: "Set Ansible values"
+  set_fact:
+    klaytn_node_DATA_DIR: "/var/{{ klaytn_service_type }}/data"
+  when:
+    - remoteNode|bool
+
+- name: "Configure Bridge"
+  include_tasks: "bridge.yml"
+  when:
+    - remoteNode|bool
+
+- name: "Generate deploy_conf"
+  include_tasks: "gen_bridge_info.yml"
+  when:
+    - gen_bridge_info|bool

--- a/roles/klaytn_bridge/templates/bridge_info.j2
+++ b/roles/klaytn_bridge/templates/bridge_info.j2
@@ -1,0 +1,12 @@
+{
+  "parent": {
+    "url": "http://{{ hostvars['PARENT0']['ansible_host'] }}:{{ parent_rpc_port }}",
+    "key": "{{ hostvars['PARENT0']['parent_nodekey'] }}",
+    "operator": {{ hostvars['CHILD0']['parent_operator'] }}
+  },
+  "child": {
+    "url": "http://{{ hostvars['CHILD0']['ansible_host'] }}:{{ child_rpc_port }}",
+    "key": "{{ hostvars['CHILD0']['child_nodekey'] }}",
+    "operator": {{ hostvars['CHILD0']['child_operator'] }}
+  }
+}

--- a/roles/klaytn_bridge/tutorial/bridge_setup.yml
+++ b/roles/klaytn_bridge/tutorial/bridge_setup.yml
@@ -1,0 +1,7 @@
+- name: Bridge_Setup
+  hosts: all
+  become: true
+  roles:
+    - role: klaytn_bridge
+      parent_service_type: "kend"
+      child_service_type: "kscnd"

--- a/roles/klaytn_bridge/vars/main.yml
+++ b/roles/klaytn_bridge/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for klaytn_bridge

--- a/roles/klaytn_node/defaults/main.yml
+++ b/roles/klaytn_node/defaults/main.yml
@@ -74,7 +74,7 @@ klaytn_network_RPC_ENABLE: 0
 klaytn_network_RPC_API: "klay,admin"
 
 # HTTP-RPC server listening port
-klaytn_network_RPC_PORT: 80
+klaytn_network_RPC_PORT: 8551
 
 # HTTP-RPC server listening interface.
 klaytn_network_RPC_ADDR: "0.0.0.0"

--- a/roles/klaytn_node/tasks/download_homi_tool.yml
+++ b/roles/klaytn_node/tasks/download_homi_tool.yml
@@ -30,8 +30,8 @@
 
 - name: Klaytn Homi Tool - Launch Homi
   shell: |
-      {{ homi_bin }} setup local --servicechain --cn-num {{ num_cn }} \
-      --test-num 1 --servicechain --p2p-port {{ serivce_chain_port }} \
+      {{ homi_bin }} setup local --cn-num {{ num_cn }} \
+      --p2p-port {{ serivce_chain_port }} \
       -o {{ homi_root }}/files/homi/output
   tags: "launchhomi"
 


### PR DESCRIPTION
This PR adds new role for bridge configuration between two chains.

After installing/configuring the nodes for the parent/child chains (e.g., EN and 4 SCNs) with the role `klaytn_node`, the user can continue to configure bridge between the two chains using this new role, `klaytn_bridge`.

The `klaytn_bridge` role has two tasks:
- `bridge.yml`: configure bridge between two chains using a pair of nodes; one on the parent chain and the other on the child chain
- `gen_bridge_info.yml`: generates `bridge_info.json` which can be used for [value transfer examples](https://github.com/klaytn/servicechain-value-transfer-examples)

Also, minor fix in the `klaytn_node` role to use `8551` as the default value for RPC port.