### PR TITLE
Update ansible to handle EN deployed using AMI

### DIFF
--- a/roles/klaytn_node/defaults/main.yml
+++ b/roles/klaytn_node/defaults/main.yml
@@ -9,6 +9,7 @@ service_chain_genesis_generatation: "no"
 service_chain_key_generation: "no"
 isServiceChain: "no"
 launchHomi: "no"
+launchKgen: "no"
 serivce_chain_port : "50505"
 
 homi_root: "/etc/playbooks/service_chain"

--- a/roles/klaytn_node/tasks/download_homi_tool.yml
+++ b/roles/klaytn_node/tasks/download_homi_tool.yml
@@ -2,7 +2,7 @@
 # description: Download/configure Klaytn Homi tool
 - name: Klaytn Homi Tool - Create Homi Directory
   file:
-    path: "{{ homi_root }}/files/homi"
+    path: "{{ homi_root }}/files/homi/output/keys"
     state: directory
     mode: "0755"
   become : yes

--- a/roles/klaytn_node/tasks/gen_nodekey.yml
+++ b/roles/klaytn_node/tasks/gen_nodekey.yml
@@ -1,0 +1,77 @@
+# description: Download/Run Klaytn kgen tool
+- name: Klaytn kgen tool - Create Directory
+  file:
+    path: "{{ homi_root }}/files/kgen"
+    state: directory
+    mode: "0755"
+  become : yes
+  when:
+    - not remoteNode|bool
+  tags: "launchKgen"
+
+- name: Klaytn kgen tool - Download Package
+  get_url:
+    url: "http://packages.klaytn.net/klaytn/{{ klaytn_homi.version }}/kgen-{{klaytn_homi.version }}-0-linux-amd64.tar.gz"
+    dest: "{{ homi_root }}/klaytn-kgen-tool.tar.gz"
+  when:
+    - not remoteNode|bool
+  tags: "launchKgen"
+
+- name: Klaytn kgen tool - Unarchive Package
+  unarchive:
+    src: "{{ homi_root }}/klaytn-kgen-tool.tar.gz"
+    dest: "{{ homi_root }}/files/kgen"
+    list_files: yes
+    keep_newer: yes
+  register: extract_result
+  when:
+    - not remoteNode|bool
+  tags: "launchKgen"
+
+- name: Klaytn kgen tool - Set kgen binary path
+  set_fact:
+    homi_bin: "{{ homi_root }}/files/kgen/{{ extract_result.files[-1] }}"
+  when:
+    - not remoteNode|bool
+  tags: "launchKgen"
+
+- name: Klaytn kgen tool - Launch kgen
+  shell: |
+    {{ homi_bin }} --file && \
+    mv {{ homi_root }}/files/kgen/keys/nodekey {{ homi_root }}/files/kgen/keys/nodekey_{{ item }}
+  args:
+    chdir: "{{ homi_root }}/files/kgen"
+  loop: "{{ groups['CypressEN'] }}"
+  when:
+    - not remoteNode|bool
+  tags: "launchKgen"
+
+- name: Copy nodekey file to EN
+  copy:
+    src: "{{ homi_root }}/files/kgen/keys/nodekey_{{ item }}"
+    dest: "{{ klaytn_node_KEY_DIR }}/nodekey"
+  loop: "{{ groups['CypressEN'] }}"
+  when:
+    - useAMI|bool
+    - remoteNode|bool
+  tags: "launchKgen"
+
+- name: "Restart Klaytn serivce"
+  command: /bin/true
+  notify:
+    - restart klaytn
+  when:
+    - ansible_facts['pkg_mgr'] == 'yum'
+    - useAMI|bool
+    - remoteNode|bool
+  tags: "launchKgen"
+
+- name: "Run Klaytn"
+  # Below command is to run Klaytn in background even after the shell opened by ansible is exited.
+  command: "nohup /opt/{{ klaytn_service_type }}/bin/{{ klaytn_service_type }} start </dev/null >/dev/null 2>&1 &"
+  become: yes
+  when:
+    - ansible_facts['pkg_mgr'] != 'yum'
+    - useAMI|bool
+    - remoteNode|bool
+  tags: "launchKgen"

--- a/roles/klaytn_node/tasks/gen_nodekey.yml
+++ b/roles/klaytn_node/tasks/gen_nodekey.yml
@@ -48,9 +48,8 @@
 
 - name: Copy nodekey file to EN
   copy:
-    src: "{{ homi_root }}/files/kgen/keys/nodekey_{{ item }}"
+    src: "{{ homi_root }}/files/kgen/keys/nodekey_{{ inventory_hostname }}"
     dest: "{{ klaytn_node_KEY_DIR }}/nodekey"
-  loop: "{{ groups['CypressEN'] }}"
   when:
     - useAMI|bool
     - remoteNode|bool

--- a/roles/klaytn_node/tasks/main.yml
+++ b/roles/klaytn_node/tasks/main.yml
@@ -57,7 +57,6 @@
 # (For Klaytn ServiceChain) Klaytn Tool installation & Generate gensis.json and nodekey
 - name: "KLAYTN HOMI TOOL"
   include_tasks: "download_homi_tool.yml"
-  tags: "sethomi"
   when:
     - service_chain_genesis_generatation|bool
     - service_chain_key_generation|bool

--- a/roles/klaytn_node/tasks/main.yml
+++ b/roles/klaytn_node/tasks/main.yml
@@ -4,24 +4,28 @@
   set_fact:
     klaytn_service_type: kcnd
     remoteNode: "yes"
+    useAMI: "no"
   when: inventory_hostname.find('CN') != -1
 
 - name: "kpnd - define Klaytn service"
   set_fact:
     klaytn_service_type : kpnd
     remoteNode: "yes"
+    useAMI: "no"
   when: inventory_hostname.find('PN') != -1
 
 - name: "kend - define Klaytn service"
   set_fact:
     klaytn_service_type : kend
     remoteNode: "yes"
+    useAMI: "yes"
   when: inventory_hostname.find('EN') != -1
 
 - name: "builder - define launch homi"
   set_fact:
     remoteNode: "no"
     isServiceChain: "yes"
+    useAMI: "no"
   when: inventory_hostname.find('builder') != -1
 
 - name: "kscnd - define Klaytn service"
@@ -29,20 +33,23 @@
     klaytn_service_type: kscnd
     isServiceChain: "yes"
     remoteNode: "yes"
+    useAMI: "no"
   when: inventory_hostname.find('SCN') != -1
 
 - name: "kspnd - define Klaytn service"
   set_fact:
-     klaytn_service_type : kspnd
-     isServiceChain: "yes"
-     remoteNode: "yes"
+    klaytn_service_type : kspnd
+    isServiceChain: "yes"
+    remoteNode: "yes"
+    useAMI: "no"
   when: inventory_hostname.find('SPN') != -1
 
 - name: "ksend - define Klaytn service"
   set_fact:
-     klaytn_service_type : ksend
-     isServiceChain: "yes"
-     remoteNode: "yes"
+    klaytn_service_type : ksend
+    isServiceChain: "yes"
+    remoteNode: "yes"
+    useAMI: "no"
   when: inventory_hostname.find('SEN') != -1
 
 - name: "Set Ansible values"
@@ -58,6 +65,7 @@
 - name: "KLAYTN HOMI TOOL"
   include_tasks: "download_homi_tool.yml"
   when:
+    - not useAMI|bool
     - service_chain_genesis_generatation|bool
     - service_chain_key_generation|bool
     - launchHomi|bool
@@ -68,6 +76,7 @@
 - name: "Service Chain Material Transfer"
   include_tasks: "cp_genesis_files.yml"
   when:
+    - not useAMI|bool
     - service_chain_genesis_generatation|bool
     - service_chain_key_generation|bool
     - remoteNode|bool
@@ -77,6 +86,7 @@
 - name: "Klaytn Package Install"
   include_tasks: "installation.yml"
   when:
+    - not useAMI|bool
     - ansible_os_family != "Windows"
     - remoteNode|bool
 
@@ -84,12 +94,14 @@
 - name: "Klaytn Node Initialization"
   include_tasks: 'initialization.yml'
   when:
+    - not useAMI|bool
     - remoteNode|bool
 
 # (For Klaytn MainChain) Download ChainData of Cypres or Baobab
 - name : "Download Chain Data"
   include_tasks: "download_chaindata.yml"
   when :
+    - not useAMI|bool
     - main_chiandata_fastsync|bool
     - not isServiceChain|bool
 
@@ -97,5 +109,12 @@
 - name: "Configure Klaytn"
   include_tasks: "configure.yml"
   when:
+    - not useAMI|bool
     - ansible_os_family != "Windows"
     - remoteNode|bool
+
+# Gen new nodekey for EN created with AMI
+- name: "Generate EN nodekey"
+  include_tasks: "gen_nodekey.yml"
+  when:
+    - ansible_os_family != "Windows"

--- a/roles/klaytn_node/tutorial/service_chain_SCN_setup.yml
+++ b/roles/klaytn_node/tutorial/service_chain_SCN_setup.yml
@@ -7,3 +7,4 @@
       service_chain_genesis_generatation : "yes"
       service_chain_key_generation: "yes"
       launchHomi: "yes"
+      launchKgen: "yes"


### PR DESCRIPTION
Current version of ansible includes tasks to install/configure Klaytn on a vanilla CentOS VM.
However, latest version of [klaytn-terraform](https://github.com/klaytn/klaytn-terraform) support using AMI for EN, which will have Klaytn installed and partially configured right after the VM has been provisioned.

So update tasks to handle AMI created EN, including
- Download `kgen` to generate new nodekey for AMI created ENs
- Copy generated nodekey to ENs

Also, a minor fix for homi directory permission is included.