### PR TITLE
Enable multiple bridge inventory host for HA support

### DIFF
--- a/roles/klaytn_bridge/inventory
+++ b/roles/klaytn_bridge/inventory
@@ -1,5 +1,7 @@
 [ParentBridgeNode]
 PARENT0 ansible_host=1.2.3.4 ansible_user=PARENT_USER
+# You can define node-specific variables here e.g., parent_rpc_port
+PARENT1 ansible_host=1.2.3.5 ansible_user=PARENT_USER parent_rpc_port=1234
 
 [ChildBridgeNode]
 CHILD0 ansible_host=5.6.7.8 ansible_user=CHILD_USER

--- a/roles/klaytn_bridge/tasks/bridge.yml
+++ b/roles/klaytn_bridge/tasks/bridge.yml
@@ -11,7 +11,6 @@
 - name: "Get parent KNI"
   set_fact:
     kni: "{{ kni_output.stdout }}"
-    num_bridge: "{{ groups['ParentChainNode'] | length }}"
   when:
     - remoteNode|bool
     - isParent|bool

--- a/roles/klaytn_bridge/tasks/bridge.yml
+++ b/roles/klaytn_bridge/tasks/bridge.yml
@@ -11,29 +11,25 @@
 - name: "Get parent KNI"
   set_fact:
     kni: "{{ kni_output.stdout }}"
+    num_bridge: "{{ groups['ParentChainNode'] | length }}"
   when:
     - remoteNode|bool
     - isParent|bool
 
 - name: "Generate main bridges json file"
   copy:
-    #content: "{{ kni }}"
-    content: "[{{ hostvars['PARENT0']['kni'] }}]"
+    content: "[{{ hostvars[inventory_hostname | regex_replace('CHILD', 'PARENT')]['kni'] }}]"
     dest: "{{ klaytn_node_DATA_DIR }}/main-bridges.json"
     force: yes
   when:
     - remoteNode|bool
     - not isParent|bool
 
-- debug: msg="{{ hostvars['PARENT0']['kni'] }}"
-  tags:
-    bridge
-
 - name: Modify main bridges json file
   replace:
     path: "{{ klaytn_node_DATA_DIR }}/main-bridges.json"
     regexp: "(@\\[\\:\\:\\]\\:\\d{1,5}\\?)"
-    replace: "@{{ hostvars['PARENT0']['ansible_host'] }}:{{ parent_bridge_port }}?"
+    replace: "@{{ hostvars[inventory_hostname | regex_replace('CHILD', 'PARENT')]['ansible_host'] }}:{{ parent_bridge_port }}?"
   when:
     - remoteNode|bool
     - not isParent|bool

--- a/roles/klaytn_bridge/tasks/gen_bridge_info.yml
+++ b/roles/klaytn_bridge/tasks/gen_bridge_info.yml
@@ -66,7 +66,8 @@
 - name: "Generate bridge_info.json file"
   template:
     src: "bridge_info.j2"
-    dest: "{{ ansible_env.PWD }}/bridge_info.json"
+    dest: "{{ ansible_env.PWD }}/bridge_info{{ item }}.json"
+  with_sequence: start=0 count={{ groups['ParentChainNode'] | length }}
   when:
     - not remoteNode|bool
 

--- a/roles/klaytn_bridge/tasks/gen_bridge_info.yml
+++ b/roles/klaytn_bridge/tasks/gen_bridge_info.yml
@@ -66,8 +66,7 @@
 - name: "Generate bridge_info.json file"
   template:
     src: "bridge_info.j2"
-    dest: "{{ ansible_env.PWD }}/bridge_info{{ item }}.json"
-  with_sequence: start=0 count={{ groups['ParentChainNode'] | length }}
+    dest: "{{ ansible_env.PWD }}/bridge_info.json"
   when:
     - not remoteNode|bool
 

--- a/roles/klaytn_bridge/tasks/main.yml
+++ b/roles/klaytn_bridge/tasks/main.yml
@@ -5,6 +5,7 @@
     klaytn_service_type: "{{ parent_service_type }}"
     isParent: "yes"
     remoteNode: "yes"
+    parent_rpc_port: "{{ parent_rpc_port }}"
   when: inventory_hostname.find('PARENT') != -1
 
 - name: "child chain"
@@ -12,6 +13,7 @@
     klaytn_service_type: "{{ child_service_type }}"
     isParent: "no"
     remoteNode: "yes"
+    child_rpc_port: "{{ child_rpc_port }}"
   when: inventory_hostname.find('CHILD') != -1
 
 - name: "builder"

--- a/roles/klaytn_bridge/templates/bridge_info.j2
+++ b/roles/klaytn_bridge/templates/bridge_info.j2
@@ -1,12 +1,12 @@
 {
   "parent": {
-    "url": "http://{{ hostvars['PARENT0']['ansible_host'] }}:{{ parent_rpc_port }}",
-    "key": "{{ hostvars['PARENT0']['parent_nodekey'] }}",
-    "operator": {{ hostvars['CHILD0']['parent_operator'] }}
+    "url": "http://{{ hostvars['PARENT' + item]['ansible_host'] }}:{{ hostvars['PARENT' + item]['parent_rpc_port'] }}",
+    "key": "{{ hostvars['PARENT' + item]['parent_nodekey'] }}",
+    "operator": {{ hostvars['CHILD' + item]['parent_operator'] }}
   },
   "child": {
-    "url": "http://{{ hostvars['CHILD0']['ansible_host'] }}:{{ child_rpc_port }}",
-    "key": "{{ hostvars['CHILD0']['child_nodekey'] }}",
-    "operator": {{ hostvars['CHILD0']['child_operator'] }}
+    "url": "http://{{ hostvars['CHILD' + item]['ansible_host'] }}:{{ hostvars['CHILD' + item]['child_rpc_port'] }}",
+    "key": "{{ hostvars['CHILD' + item]['child_nodekey'] }}",
+    "operator": {{ hostvars['CHILD' + item]['child_operator'] }}
   }
 }

--- a/roles/klaytn_bridge/templates/bridge_info.j2
+++ b/roles/klaytn_bridge/templates/bridge_info.j2
@@ -1,12 +1,18 @@
 {
-  "parent": {
-    "url": "http://{{ hostvars['PARENT' + item]['ansible_host'] }}:{{ hostvars['PARENT' + item]['parent_rpc_port'] }}",
-    "key": "{{ hostvars['PARENT' + item]['parent_nodekey'] }}",
-    "operator": {{ hostvars['CHILD' + item]['parent_operator'] }}
+  "sender": {
+    "child": {
+      "key": "{{ hostvars['CHILD0']['child_nodekey'] }}"
+    },
+    "parent": {
+      "key": "{{ hostvars['PARENT0']['parent_nodekey'] }}"
+    }
   },
-  "child": {
-    "url": "http://{{ hostvars['CHILD' + item]['ansible_host'] }}:{{ hostvars['CHILD' + item]['child_rpc_port'] }}",
-    "key": "{{ hostvars['CHILD' + item]['child_nodekey'] }}",
-    "operator": {{ hostvars['CHILD' + item]['child_operator'] }}
+  "url": {
+    "parent": "http://{{ hostvars['PARENT0']['ansible_host'] }}:{{ hostvars['PARENT0']['parent_rpc_port'] }}",
+    "children": [
+{% for host in groups['ChildChainNode'] %}
+      "http://{{ hostvars[host]['ansible_host'] }}:{{ hostvars[host]['child_rpc_port'] }}"{{ "," if not loop.last else "" }}
+{% endfor %}
+    ]
   }
 }


### PR DESCRIPTION
This PR enables to use multiple parent and child host in the inventory file for `klaytn_bridge` role.
It adds HA supports for bridge, e.g., 2 pairs of EN <> SCN bridge.

Also, remove some obsolete codes.