### PR TITLE
Change homi_root to remove sudo permission in builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+klaytn-temp

--- a/roles/klaytn_node/defaults/main.yml
+++ b/roles/klaytn_node/defaults/main.yml
@@ -12,7 +12,7 @@ launchHomi: "no"
 launchKgen: "no"
 serivce_chain_port : "50505"
 
-homi_root: "/tmp/klaytn-ansible/klaytn-temp"
+homi_root: "{{ playbook_dir }}/klaytn-temp"
 
 
 ################### KLAYTN CONFIGURATION VARIABLES ##################################################

--- a/roles/klaytn_node/defaults/main.yml
+++ b/roles/klaytn_node/defaults/main.yml
@@ -12,7 +12,7 @@ launchHomi: "no"
 launchKgen: "no"
 serivce_chain_port : "50505"
 
-homi_root: "/etc/playbooks/service_chain"
+homi_root: "/tmp/klaytn-ansible/klaytn-temp"
 
 
 ################### KLAYTN CONFIGURATION VARIABLES ##################################################

--- a/roles/klaytn_node/tasks/cp_genesis_files.yml
+++ b/roles/klaytn_node/tasks/cp_genesis_files.yml
@@ -9,20 +9,24 @@
 
 - name: Copy genesis file to scn
   copy:
-    src: "{{ homi_root }}/files/homi/output/scripts/genesis.json"
+    src: "{{ homi_root }}/output/scripts/genesis.json"
     dest: "{{ klaytn_node_GENESIS_DIR }}/genesis.json"
+  become: yes
 
 - name: Copy static-nodes file to scn
   copy:
-    src: "{{ homi_root }}/files/homi/output/static-nodes.json"
+    src: "{{ homi_root }}/output/static-nodes.json"
     dest: "{{ klaytn_node_DATA_DIR }}/static-nodes.json"
+  become: yes
 
 - name: Copy key file to scn
   copy:
-    src: "{{ homi_root }}/files/homi/output/keys/nodekey_{{ inventory_hostname }}"
+    src: "{{ homi_root }}/output/keys/nodekey_{{ inventory_hostname }}"
     dest: "{{ klaytn_node_KEY_DIR }}/nodekey"
+  become: yes
 
 - name: Copy validator file to scn
   copy:
-    src: "{{ homi_root }}/files/homi/output/keys/validator_{{ inventory_hostname }}"
+    src: "{{ homi_root }}/output/keys/validator_{{ inventory_hostname }}"
     dest: "{{ klaytn_node_GENESIS_DIR }}/"
+  become: yes

--- a/roles/klaytn_node/tasks/download_homi_tool.yml
+++ b/roles/klaytn_node/tasks/download_homi_tool.yml
@@ -2,10 +2,9 @@
 # description: Download/configure Klaytn Homi tool
 - name: Klaytn Homi Tool - Create Homi Directory
   file:
-    path: "{{ homi_root }}/files/homi/output/keys"
+    path: "{{ homi_root }}/homi"
     state: directory
     mode: "0755"
-  become : yes
 
 - name: Klaytn Homi Tool - Download Package
   get_url:
@@ -15,14 +14,14 @@
 - name: Klaytn Homi Tool - Unarchive Package
   unarchive:
     src: "{{ homi_root }}/klaytn-homi-tool.tar.gz"
-    dest: "{{ homi_root }}/files/homi"
+    dest: "{{ homi_root }}/homi"
     list_files: yes
     keep_newer: yes
   register: extract_result
 
 - name: Klaytn Homi Tool - Set homi binary path
   set_fact:
-    homi_bin: "{{ homi_root }}/files/homi/{{ extract_result.files[-1] }}"
+    homi_bin: "{{ homi_root }}/homi/{{ extract_result.files[-1] }}"
     num_cn: "{{ groups['ServiceChainCN'] | length }}"
     static_nodes_json: []
     static_nodes_knis: []
@@ -32,12 +31,12 @@
   shell: |
       {{ homi_bin }} setup local --cn-num {{ num_cn }} \
       --p2p-port {{ serivce_chain_port }} \
-      -o {{ homi_root }}/files/homi/output
+      -o {{ homi_root }}/output
   tags: "launchhomi"
 
 - name: Klaytn Homi Tool - Modify validator file
   replace:
-    path: "{{ homi_root }}/files/homi/output/keys/validator{{ cn_idx +1 }}"
+    path: "{{ homi_root }}/output/keys/validator{{ cn_idx +1 }}"
     regexp: "(@[0-9]\\.[0-9]\\.[0-9]\\.[0-9]\\:\\d{1,5}\\?)"
     replace: "@{{ hostvars[item]['ansible_host'] }}?"
   loop: "{{ groups['ServiceChainCN'] }}"
@@ -46,7 +45,7 @@
 
 - name: Klaytn Homi Tool - Get static nodes json variable
   set_fact:
-    static_nodes_json:  "{{ static_nodes_json + [ lookup('file', homi_root + '/files/homi/output/keys/validator' + ( (cn_idx + 1) | string) ) | from_json  ] }}"
+    static_nodes_json:  "{{ static_nodes_json + [ lookup('file', homi_root + '/output/keys/validator' + ( (cn_idx + 1) | string) ) | from_json  ] }}"
   loop: "{{ groups['ServiceChainCN'] }}"
   loop_control:
     index_var: cn_idx
@@ -60,17 +59,17 @@
 - name: Klaytn Homi Tool - Generate static-nodes.json
   copy:
     content: "{{ static_nodes_knis  }}"
-    dest: "{{ homi_root }}/files/homi/output/static-nodes.json"
+    dest: "{{ homi_root }}/output/static-nodes.json"
     force: yes
 
 - name: Modify nodekey name with SCN name
-  command: mv "{{ homi_root }}/files/homi/output/keys/nodekey{{ scn_idx +1 }}" "{{ homi_root }}/files/homi/output/keys/nodekey_{{ item }}"
+  command: mv "{{ homi_root }}/output/keys/nodekey{{ scn_idx +1 }}" "{{ homi_root }}/output/keys/nodekey_{{ item }}"
   loop: "{{ groups['ServiceChainCN'] }}"
   loop_control:
     index_var: scn_idx
 
 - name: Modify validator name with SCN name
-  command: mv "{{ homi_root }}/files/homi/output/keys/validator{{ scn_idx +1 }}" "{{ homi_root }}/files/homi/output/keys/validator_{{ item }}"
+  command: mv "{{ homi_root }}/output/keys/validator{{ scn_idx +1 }}" "{{ homi_root }}/output/keys/validator_{{ item }}"
   loop: "{{ groups['ServiceChainCN'] }}"
   loop_control:
     index_var: scn_idx

--- a/roles/klaytn_node/tasks/gen_nodekey.yml
+++ b/roles/klaytn_node/tasks/gen_nodekey.yml
@@ -1,10 +1,9 @@
 # description: Download/Run Klaytn kgen tool
 - name: Klaytn kgen tool - Create Directory
   file:
-    path: "{{ homi_root }}/files/kgen"
+    path: "{{ homi_root }}/kgen"
     state: directory
     mode: "0755"
-  become : yes
   when:
     - not remoteNode|bool
   tags: "launchKgen"
@@ -20,7 +19,7 @@
 - name: Klaytn kgen tool - Unarchive Package
   unarchive:
     src: "{{ homi_root }}/klaytn-kgen-tool.tar.gz"
-    dest: "{{ homi_root }}/files/kgen"
+    dest: "{{ homi_root }}/kgen"
     list_files: yes
     keep_newer: yes
   register: extract_result
@@ -30,7 +29,7 @@
 
 - name: Klaytn kgen tool - Set kgen binary path
   set_fact:
-    homi_bin: "{{ homi_root }}/files/kgen/{{ extract_result.files[-1] }}"
+    homi_bin: "{{ homi_root }}/kgen/{{ extract_result.files[-1] }}"
   when:
     - not remoteNode|bool
   tags: "launchKgen"
@@ -38,9 +37,9 @@
 - name: Klaytn kgen tool - Launch kgen
   shell: |
     {{ homi_bin }} --file && \
-    mv {{ homi_root }}/files/kgen/keys/nodekey {{ homi_root }}/files/kgen/keys/nodekey_{{ item }}
+    mv {{ homi_root }}/kgen/keys/nodekey {{ homi_root }}/kgen/keys/nodekey_{{ item }}
   args:
-    chdir: "{{ homi_root }}/files/kgen"
+    chdir: "{{ homi_root }}/kgen"
   loop: "{{ groups['CypressEN'] }}"
   when:
     - not remoteNode|bool
@@ -48,8 +47,9 @@
 
 - name: Copy nodekey file to EN
   copy:
-    src: "{{ homi_root }}/files/kgen/keys/nodekey_{{ inventory_hostname }}"
+    src: "{{ homi_root }}/kgen/keys/nodekey_{{ inventory_hostname }}"
     dest: "{{ klaytn_node_KEY_DIR }}/nodekey"
+  become: yes
   when:
     - useAMI|bool
     - remoteNode|bool

--- a/roles/klaytn_node/tasks/main.yml
+++ b/roles/klaytn_node/tasks/main.yml
@@ -26,6 +26,7 @@
     remoteNode: "no"
     isServiceChain: "yes"
     useAMI: "no"
+    homi_root: "{{ playbook_dir }}/klaytn-temp"
   when: inventory_hostname.find('builder') != -1
 
 - name: "kscnd - define Klaytn service"
@@ -34,6 +35,7 @@
     isServiceChain: "yes"
     remoteNode: "yes"
     useAMI: "no"
+    homi_root: "{{ playbook_dir }}/klaytn-temp"
   when: inventory_hostname.find('SCN') != -1
 
 - name: "kspnd - define Klaytn service"

--- a/roles/klaytn_node/tasks/main.yml
+++ b/roles/klaytn_node/tasks/main.yml
@@ -26,7 +26,6 @@
     remoteNode: "no"
     isServiceChain: "yes"
     useAMI: "no"
-    homi_root: "{{ playbook_dir }}/klaytn-temp"
   when: inventory_hostname.find('builder') != -1
 
 - name: "kscnd - define Klaytn service"
@@ -35,7 +34,6 @@
     isServiceChain: "yes"
     remoteNode: "yes"
     useAMI: "no"
-    homi_root: "{{ playbook_dir }}/klaytn-temp"
   when: inventory_hostname.find('SCN') != -1
 
 - name: "kspnd - define Klaytn service"

--- a/roles/klaytn_node/tutorial/service_chain_SCN_setup.yml
+++ b/roles/klaytn_node/tutorial/service_chain_SCN_setup.yml
@@ -1,6 +1,5 @@
 - name: Service_Chain_SCN_SETUP
   hosts: all
-  become: true
   roles:
     - role: klaytn_node
       main_chiandata_fastsync : "no"


### PR DESCRIPTION
This PR updates homi_root from `/etc/playbooks/service_chain` to playbook directory which should be owned by user.
That allows us to stop asking passwords for sudo permission.