### PR TITLE
Add log metrics in Grafana using Telegraf

### DIFF
--- a/roles/klaytn_grafana/README.md
+++ b/roles/klaytn_grafana/README.md
@@ -20,6 +20,9 @@ See all default variables in [defaults/main.yml](defaults/main.yml)
 - `prometheus_port`: the port number of the prometheus metrics server in the Klaytn nodes (61001).
 Grafana uses this port to collect metrics from the running Klaytn nodes
 - `grafana_port`: the port number of the grafana web UI
+- `influxdb_port`: the port number of the InfluxDB server (8086)
+- `telegraf_conf_dir`: the path for the Telegraf configuration file
+- `influxdb_data_dir`: the path for the InfluxDB data directory mounted to InfluxDB container
 
 Dependencies
 ------------

--- a/roles/klaytn_grafana/defaults/main.yml
+++ b/roles/klaytn_grafana/defaults/main.yml
@@ -2,4 +2,7 @@
 # defaults file for klaytn_grafana
 prometheus_port: "61001"
 grafana_port: "3000"
-klaytn_node_list: []
+influxdb_port: "8086"
+
+telegraf_conf_dir: "/etc/telegraf"
+influxdb_data_dir: "/var/lib/influxdb"

--- a/roles/klaytn_grafana/handlers/main.yml
+++ b/roles/klaytn_grafana/handlers/main.yml
@@ -5,3 +5,10 @@
     state: restarted
     enabled: yes
   become: yes
+
+- name: restart telegraf daemon
+  systemd:
+    name: "telegraf"
+    state: restarted
+    enabled: yes
+  become: yes

--- a/roles/klaytn_grafana/inventory
+++ b/roles/klaytn_grafana/inventory
@@ -1,2 +1,6 @@
 [Grafana]
-GRAFANA0 ansible_host=1.2.3.4 ansible_user=MY_USER klaytn_node_list=["1.2.3.4", "5.6.7.8"]
+GRAFANA0 ansible_host=1.2.3.4 ansible_user=MY_USER
+
+[KlaytnNode]
+EN0 ansible_host=5.6.7.8 ansible_user=EN_USER
+SCN0 ansible_host=6.7.8.9 ansible_user=SCN_USER

--- a/roles/klaytn_grafana/meta/main.yml
+++ b/roles/klaytn_grafana/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   author:
     - sawyer.lee@krustuniverse.com
-  description: "Klaytn BlockChain Bridge Configuration"
+  description: "Klaytn BlockChain Grafana Configuration"
   company: Krust Universe
   license: MIT
   min_ansible_version: 2.4

--- a/roles/klaytn_grafana/tasks/grafana.yml
+++ b/roles/klaytn_grafana/tasks/grafana.yml
@@ -1,25 +1,27 @@
 # description: Setup grafana
-- name: "Make configuration directory"
+- name: "Make data and configuration directory"
   file:
     path: "{{ item }}"
     state: "directory"
   with_items:
-    ["{{ grafana_conf_dir }}/provisioning/datasources", "{{ grafana_conf_dir }}/provisioning/dashboards"]
+    ["{{ grafana_conf_dir }}/provisioning/datasources", "{{ grafana_conf_dir }}/provisioning/dashboards", "{{ influxdb_data_dir }}"]
   become: yes
 
 - name: "Grafana Configuration with templates"
   template:
-    src: "prometheus.yml.j2"
-    dest: "{{ grafana_conf_dir }}/prometheus.yml"
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
     force: yes
   become: yes
+  with_items:
+    - { src: "templates/prometheus.yml.j2", dest: "{{ grafana_conf_dir }}/prometheus.yml" }
+    - { src: "templates/klaytn.yml.j2", dest: "{{ grafana_conf_dir }}/provisioning/datasources/klaytn.yml" }
 
 - name: "Copy static files"
   copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   with_items:
-    - { src: "templates/klaytn.yml", dest: "{{ grafana_conf_dir }}/provisioning/datasources/klaytn.yml" }
     - { src: "templates/klaytn-dashboard.yml", dest: "{{ grafana_conf_dir }}/provisioning/dashboards/klaytn-dashboard.yml" }
     - { src: "templates/grafana_klaytn.json", dest: "{{ grafana_conf_dir }}/provisioning/dashboards/grafana_klaytn.json" }
     - { src: "templates/grafana_klaytn_data.json", dest: "{{ grafana_conf_dir }}/provisioning/dashboards/grafana_klaytn_data.json" }
@@ -27,6 +29,7 @@
     - { src: "templates/grafana_klaytn_miner.json", dest: "{{ grafana_conf_dir }}/provisioning/dashboards/grafana_klaytn_minor.json" }
     - { src: "templates/grafana_klaytn_network.json", dest: "{{ grafana_conf_dir }}/provisioning/dashboards/grafana_klaytn_network.json" }
     - { src: "templates/grafana_klaytn_service_chain.json", dest: "{{ grafana_conf_dir }}/provisioning/dashboards/grafana_klaytn_service_chain.json" }
+    - { src: "templates/grafana_klaytn_log.json", dest: "{{ grafana_conf_dir }}/provisioning/dashboards/grafana_klaytn_log.json" }
   become: yes
 
 - name: "Install docker"
@@ -56,6 +59,24 @@
     image: prom/prometheus
     volumes:
       - /etc/grafana/conf/prometheus.yml:/etc/prometheus/prometheus.yml
+    network_mode: host
+    restart_policy: always
+    state: started
+    detach: yes
+  become: yes
+
+- name: "Run influxdb docker"
+  docker_container:
+    name: influxdb
+    image: influxdb:1.8
+    volumes:
+      - /var/lib/influxdb:/var/lib/influxdb
+    env:
+      INFLUXDB_DB: klaytn_logs
+      INFLUXDB_ADMIN_USER: admin
+      INFLUXDB_ADMIN_PASSWROD: adminpass
+      INFLUXDB_USER: user
+      INFLUXDB_USER_PASSWORD: userpass
     network_mode: host
     restart_policy: always
     state: started

--- a/roles/klaytn_grafana/tasks/grafana.yml
+++ b/roles/klaytn_grafana/tasks/grafana.yml
@@ -7,6 +7,11 @@
     ["{{ grafana_conf_dir }}/provisioning/datasources", "{{ grafana_conf_dir }}/provisioning/dashboards", "{{ influxdb_data_dir }}"]
   become: yes
 
+- name: "Generate random strings for InfluxDB password"
+  set_fact:
+    adminpass: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters') }}"
+    userpass: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters') }}"
+
 - name: "Grafana Configuration with templates"
   template:
     src: "{{ item.src }}"
@@ -70,13 +75,14 @@
     name: influxdb
     image: influxdb:1.8
     volumes:
-      - /var/lib/influxdb:/var/lib/influxdb
+      - "{{ influxdb_data_dir }}:/var/lib/influxdb"
     env:
       INFLUXDB_DB: klaytn_logs
       INFLUXDB_ADMIN_USER: admin
-      INFLUXDB_ADMIN_PASSWROD: adminpass
+      INFLUXDB_ADMIN_PASSWORD: "{{ adminpass }}"
       INFLUXDB_USER: user
-      INFLUXDB_USER_PASSWORD: userpass
+      INFLUXDB_USER_PASSWORD: "{{ userpass }}"
+      INFLUXDB_HTTP_BIND_ADDRESS: ":{{ influxdb_port }}"
     network_mode: host
     restart_policy: always
     state: started

--- a/roles/klaytn_grafana/tasks/main.yml
+++ b/roles/klaytn_grafana/tasks/main.yml
@@ -1,11 +1,47 @@
 ---
-# tasks file for klaytn_bridge
+# tasks file for klaytn_grafana
+- name: "kcnd - define Klaytn service"
+  set_fact:
+    klaytn_service_type: kcnd
+  when: inventory_hostname.find('CN') != -1
+
+- name: "kpnd - define Klaytn service"
+  set_fact:
+    klaytn_service_type : kpnd
+  when: inventory_hostname.find('PN') != -1
+
+- name: "kend - define Klaytn service"
+  set_fact:
+    klaytn_service_type : kend
+  when: inventory_hostname.find('EN') != -1
+
+- name: "kscnd - define Klaytn service"
+  set_fact:
+    klaytn_service_type: kscnd
+  when: inventory_hostname.find('SCN') != -1
+
+- name: "kspnd - define Klaytn service"
+  set_fact:
+    klaytn_service_type : kspnd
+  when: inventory_hostname.find('SPN') != -1
+
+- name: "ksend - define Klaytn service"
+  set_fact:
+    klaytn_service_type : ksend
+  when: inventory_hostname.find('SEN') != -1
+
 - name: "grafana"
   set_fact:
     isGrafana: "yes"
     prometheus_port: "{{ prometheus_port }}"
     grafana_port: "{{ grafana_port }}"
+    influxdb_port: "{{ influxdb_port }}"
   when: inventory_hostname.find('GRAFANA') != -1
+
+- name: "Klaytn nodes"
+  set_fact:
+    isGrafana: "no"
+  when: inventory_hostname.find('GRAFANA') == -1
 
 - name: "Set Ansible values"
   set_fact:
@@ -13,7 +49,19 @@
   when:
     - isGrafana|bool
 
+- name: "Set Ansible values"
+  set_fact:
+    telegraf_conf_dir: "/etc/telegraf"
+    klaytn_log_dir: "/var/{{ klaytn_service_type }}/log"
+  when:
+    - not isGrafana|bool
+
 - name: "Install and configure grafana"
-  include_tasks: "setup_grafana.yml"
+  include_tasks: "grafana.yml"
   when:
     - isGrafana|bool
+
+- name: "Install and configure telegraf"
+  include_tasks: "telegraf.yml"
+  when:
+    - not isGrafana|bool

--- a/roles/klaytn_grafana/tasks/telegraf.yml
+++ b/roles/klaytn_grafana/tasks/telegraf.yml
@@ -1,0 +1,61 @@
+---
+# RedHat & CentOS specific installation
+- name: "Add yum repository for InfluxDB"
+  yum_repository:
+    name: influxdb
+    description: InfluxDB Repository
+    baseurl: https://repos.influxdata.com/rhel/7/x86_64/stable
+    gpgcheck: no
+  become: yes
+  when: ansible_facts['pkg_mgr'] == 'yum'
+
+- name: "Install Telegraf with yum"
+  yum:
+    name: 'telegraf'
+    state: latest
+  register: is_telegraf_installed
+  until: is_telegraf_installed is succeeded
+  become: yes
+  when: ansible_facts['pkg_mgr'] == 'yum'
+
+# Ubuntu & Debian specific installation
+- name: "Add apt repository for InfluxDB"
+  shell: |
+    wget -qO- https://repos.influxdata.com/influxdb.key | sudo tee /etc/apt/trusted.gpg.d/influxdb.asc >/dev/null
+    source /etc/os-release
+    echo "deb https://repos.influxdata.com/${ID} ${VERSION_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+  become: yes
+  when: ansible_facts['pkg_mgr'] != 'yum'
+
+# TODO: This is a temporary measure for cases when AMI already have existing telegraf config, and should be removed after that issue is resolved.
+- name: "Remove remaining telegraf directory if exist"
+  file:
+    path: "/etc/telegraf/telegraf.d"
+    state: absent
+  become: yes
+
+- name: "Install Telegraf with apt"
+  apt:
+    name: telegraf
+    update_cache: yes
+    state: latest
+  become: yes
+  when: ansible_facts['pkg_mgr'] != 'yum'
+
+- name: "Make Telegraf directory if not exists"
+  file:
+    path: "{{ telegraf_conf_dir }}"
+    state: "directory"
+  become: yes
+
+- name: "Telegraf Configuration with template"
+  template:
+    src: "telegraf.conf.j2"
+    dest: "{{ telegraf_conf_dir }}/telegraf.conf"
+    force: yes
+  become: yes
+
+- name: "Restart Telegraf daemon"
+  command: /bin/true
+  notify:
+    - restart telegraf daemon

--- a/roles/klaytn_grafana/templates/grafana_klaytn_log.json
+++ b/roles/klaytn_grafana/templates/grafana_klaytn_log.json
@@ -1,0 +1,1117 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_KLAYTN_LOGS",
+      "label": "Klaytn_Logs",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.4.6"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1655069078910,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 17,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "content": "<center><h1>Logs Counts & Lastest Logs</h1>\n\n\n",
+        "mode": "html"
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "klaytn_logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "": {
+                  "text": ""
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "min": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 2
+      },
+      "id": 4,
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "8.4.6",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "host"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "limit": "",
+          "measurement": "klaytn_log",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT count(\"value\") FROM \"klaytn_log\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY \"host\" fill(linear)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "count"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "title": "Log count",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "klaytn_logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "auto"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 219
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "host"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 81
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 13,
+        "x": 4,
+        "y": 2
+      },
+      "id": 6,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(value) as \"Lastest Logs\" FROM \"klaytn_log\" WHERE $timeFilter GROUP BY \"host\";",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Lastest Log",
+      "transformations": [],
+      "type": "table"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 4,
+        "x": 7,
+        "y": 8
+      },
+      "id": 16,
+      "options": {
+        "content": "\n\n\n",
+        "mode": "html"
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 17,
+        "x": 0,
+        "y": 9
+      },
+      "id": 13,
+      "options": {
+        "content": "\n<center><h1>INFO vs ERROR counts</h1></center>\n\n\n\n",
+        "mode": "html"
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "klaytn_logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 11
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT count(\"value\") FROM \"klaytn_log\" WHERE (\"host\" =~ /^$host$/ AND \"value\" =~ /INFO*/) AND $timeFilter GROUP BY \"host\" fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "INFO counts",
+      "type": "stat"
+    },
+    {
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 6,
+        "y": 11
+      },
+      "id": 15,
+      "options": {
+        "content": "\n\n\n",
+        "mode": "html"
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "klaytn_logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 11,
+        "y": 11
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT count(\"value\") FROM \"klaytn_log\" WHERE (\"host\" =~ /^$host$/ AND \"value\" =~ /ERR*/) AND $timeFilter GROUP BY \"host\" fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "ERROR counts",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "klaytn_logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "auto"
+          },
+          "mappings": [
+            {
+              "options": {
+                "": {
+                  "text": ""
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Volume"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 176
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "host"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 171
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Host"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 17,
+        "x": 0,
+        "y": 15
+      },
+      "id": 10,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Time"
+          }
+        ]
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"host\" as \"Host\", \"value\" as \"Klaytn_Log\" FROM klaytn_logs.autogen.klaytn_log WHERE $timeFilter AND (\"host\" =~ /^$host$/)  AND \"value\" =~ /ERR*/\n",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "ERROR Logs",
+      "type": "table"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 4,
+        "x": 7,
+        "y": 20
+      },
+      "id": 17,
+      "options": {
+        "content": "\n\n\n",
+        "mode": "html"
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 17,
+        "x": 0,
+        "y": 21
+      },
+      "id": 14,
+      "options": {
+        "content": "<center><h1> Logs Detail</h1> </center>\n\n\n\n",
+        "mode": "html"
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "klaytn_logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "auto"
+          },
+          "mappings": [
+            {
+              "options": {
+                "": {
+                  "text": ""
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Volume"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 176
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "host"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 171
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Host"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 21,
+        "w": 17,
+        "x": 0,
+        "y": 23
+      },
+      "id": 2,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Time"
+          }
+        ]
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"host\" as \"Host\", \"value\" as \"Klaytn_Log\" FROM klaytn_logs.autogen.klaytn_log WHERE $timeFilter AND (\"host\" =~ /^$host$/) \n",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Klaytn Logs",
+      "type": "table"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "influxdb",
+          "uid": "klaytn_logs"
+        },
+        "definition": "show tag values on \"klaytn_logs\" with key = \"host\"",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "host",
+        "options": [],
+        "query": "show tag values on \"klaytn_logs\" with key = \"host\"",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Baobab - Klaytn Logs",
+  "uid": "h06MrhsMk",
+  "version": 16,
+  "weekStart": ""
+}

--- a/roles/klaytn_grafana/templates/klaytn.yml.j2
+++ b/roles/klaytn_grafana/templates/klaytn.yml.j2
@@ -1,12 +1,23 @@
 # provisioning/datasources/all.yml
 # https://github.com/cirocosta/sample-grafana/blob/master/grafana/provisioning/datasources/all.yml
+apiVersion: 1
 
 datasources:
 -  access: 'proxy'                       # make grafana perform the requests
    editable: true                        # whether it should be editable
    is_default: true                      # whether this should be the default DS
-   name: 'klaytn'                         # name of the datasource
+   name: 'klaytn'                        # name of the datasource
    org_id: 1                             # id of the organization to tie this datasource to
    type: 'prometheus'                    # type of the data source
-   url: 'http://localhost:9090'         # url of the prom instance
+   url: 'http://localhost:9090'          # url of the prom instance
    version: 1                            # well, versioning
+- name: 'klaytn_logs'
+  type: 'influxdb'
+  access: 'proxy'
+  database: 'klaytn_logs'
+  user: 'user'
+  url: 'http://localhost:8086'
+  jsonData:
+    httpMode: 'GET'
+  secureJsonData:
+    password: 'userpass'

--- a/roles/klaytn_grafana/templates/klaytn.yml.j2
+++ b/roles/klaytn_grafana/templates/klaytn.yml.j2
@@ -16,8 +16,8 @@ datasources:
   access: 'proxy'
   database: 'klaytn_logs'
   user: 'user'
-  url: 'http://localhost:8086'
+  url: 'http://localhost:{{ influxdb_port }}'
   jsonData:
     httpMode: 'GET'
   secureJsonData:
-    password: 'userpass'
+    password: '{{ userpass }}'

--- a/roles/klaytn_grafana/templates/prometheus.yml.j2
+++ b/roles/klaytn_grafana/templates/prometheus.yml.j2
@@ -6,6 +6,6 @@ scrape_configs:
   - job_name: 'klaytn'
     static_configs:
     - targets:
-{% for host in klaytn_node_list %}
-      - "{{ host }}:{{ prometheus_port }}"
+{% for host in groups['KlaytnNode'] %}
+      - "{{ hostvars[host]['ansible_host'] }}:{{ prometheus_port }}"
 {% endfor %}

--- a/roles/klaytn_grafana/templates/telegraf.conf.j2
+++ b/roles/klaytn_grafana/templates/telegraf.conf.j2
@@ -16,5 +16,5 @@
 [[outputs.influxdb]]
   urls = [{% for host in groups['Grafana'] %}"http://{{ hostvars[host].ansible_all_ipv4_addresses | ipaddr('10.0.0.0/8') | first }}:{{ hostvars[host]['influxdb_port'] }}"{{ "," if not loop.last else "" }}{% endfor %}]
   username = "user"
-  password = "userpass"
+  password = "{{ hostvars[groups['Grafana'][0]].userpass }}"
   database = "klaytn_logs"

--- a/roles/klaytn_grafana/templates/telegraf.conf.j2
+++ b/roles/klaytn_grafana/templates/telegraf.conf.j2
@@ -1,0 +1,20 @@
+[global_tags]
+  nodetype = "{{ klaytn_service_type | regex_replace('[k,d]') }}"
+
+  instance = "{{ inventory_hostname }}"
+
+[agent]
+  hostname = "{{ inventory_hostname }}"
+
+[[inputs.tail]]
+  files = ["{{ klaytn_log_dir }}/{{ klaytn_service_type }}.out"]
+  from_beginning = false
+  name_override = "klaytn_log"
+  data_format = "grok"
+  grok_patterns = ["%{GREEDYDATA:value:string}"]
+
+[[outputs.influxdb]]
+  urls = [{% for host in groups['Grafana'] %}"http://{{ hostvars[host].ansible_all_ipv4_addresses | ipaddr('10.0.0.0/8') | first }}:{{ hostvars[host]['influxdb_port'] }}"{{ "," if not loop.last else "" }}{% endfor %}]
+  username = "user"
+  password = "userpass"
+  database = "klaytn_logs"


### PR DESCRIPTION
This PR adds tasks for configuring Grafana to show log metrics (number of logs, latest logs, number of error logs, etc.).

Below shows how log metrics are processed.
1. Klaytn node write logs to log file
2. Telegraf watches the log file and send newly added logs to InfluxDB
3. The log dashboard in Grafana uses the InfluxDB as its datasource and displays log metrics

The Telegraf should be run in each Klaytn nodes, and the InfluxDB is running in the Grafana instance (where Grafana and Prometheus services are running).

Provisioning alert rules using script seems not yet supported by Grafana, so the user should configure alert rules using Grafana web UI.

Note that this PR includes some tasks to remove remaining Telegraf configuration in the Baobab EN AMI, and those tasks will be removed after the issue has been resolved.