### PR TITLE
[KNI] Fixed wrong regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ First, update inventory.
 
 ```
 [ServiceChainCN]
-SCN1 ansible_user=MY_USER ansible_host=1.2.3.4
+SCN1 ansible_user=MY_USER ansible_host=1.2.3.4 ansible_ssh_private_key_file=/home/myuser/.ssh/mykey.pem
 
 [controller]
 builder ansible_host=localhost ansible_connecion=local ansible_user=YOUR_USER

--- a/roles/klaytn_bridge/tasks/bridge.yml
+++ b/roles/klaytn_bridge/tasks/bridge.yml
@@ -41,7 +41,7 @@
 - name: Modify main bridges json file
   replace:
     path: "{{ klaytn_node_DATA_DIR }}/main-bridges.json"
-    regexp: "@0.0.0.0:0"
+    regexp: "\\@\\[::\\]:32323"
     replace: "@{{ hostvars[inventory_hostname | regex_replace('CHILD', 'PARENT')]['privateIP'] }}:{{ parent_bridge_port }}"
   become: yes
   when:

--- a/roles/klaytn_grafana/README.md
+++ b/roles/klaytn_grafana/README.md
@@ -6,6 +6,8 @@ This ansible role enables you to automate grafana configuration for Klaytn.
 Requirements
 ------------
 
+`python3-netaddr` package is required. (`sudo apt install --no-install-recommends python3-netaddr` in debian)
+
 An existing Klaytn network and the node for deploying grafana.
 See [klaytn-terraform](https://github.com/klaytn/klaytn-terraform)
 if you have not prepared an existing Klaytn network.


### PR DESCRIPTION
- Added a necessary parameter `ansible_ssh_private_key_file` in README example.
- Added prerequisite installation in `roles/klaytn_grafana/README.md`
- Fixed wrong regexp in the rule of  `Modify main bridges json file`